### PR TITLE
Add basic HTTP auth to admin product controller

### DIFF
--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -1,4 +1,5 @@
 class Admin::ProductsController < ApplicationController
+  http_basic_authenticate_with name: ENV["USERNAME"], password: ENV["PASSWORD"]
 
   def index
     @products = Product.order(id: :desc).all


### PR DESCRIPTION
Add basic auth to admin product page

Authentication was done using rails' http_basic_authenticate_with method in the admin products controller. Username and password are set in the dot env file and passed into the method in a hash.